### PR TITLE
Default scope for Card

### DIFF
--- a/app/controllers/admin/cards_controller.rb
+++ b/app/controllers/admin/cards_controller.rb
@@ -2,7 +2,7 @@ class Admin::CardsController < Admin::BaseController
   load_and_authorize except: :status
 
   def index
-    @table = CardTable.new(self, @cards.where.not(status: :incomplete), search: true)
+    @table = CardTable.new(self, @cards, search: true)
   end
 
   def edit

--- a/app/controllers/cards/wizards_controller.rb
+++ b/app/controllers/cards/wizards_controller.rb
@@ -4,8 +4,7 @@ class Cards::WizardsController < ApplicationController
   layout 'admin'
 
   def new
-    # first match (rewhere is need because of default scope)
-    @card = Card.rewhere(status: :incomplete, user: current_user).first
+    @card = Card.with_incomplete.where(user: current_user).first
     if @card.nil?
       @card = current_user.cards.new
       @card.status = :incomplete
@@ -48,7 +47,7 @@ class Cards::WizardsController < ApplicationController
   end
 
   def find_incomplete_card(id)
-    Card.rewhere(id: id, status: :incomplete, user: current_user).first
+    Card.with_incomplete.where(id: id, user: current_user).first
   end
 
   def check_if_signed_in

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -3,6 +3,9 @@ class Card < ApplicationRecord
   attr_writer :tag_names
   attr_accessor :current_step
 
+  default_scope -> { where.not(status: :incomplete) }
+  scope :active_networks, -> { where(status: :online, card_type: :network) }
+
   enum card_type: [:youth, :adult, :activist, :organization, :network, :training]
   enum status: [:pending, :online, :incomplete, :change]
 
@@ -44,9 +47,9 @@ class Card < ApplicationRecord
   end
 
   def coordinates_are_both_set
-      if latitude.nil? || longitude.nil? 
-        errors.add(:base, "Veuillez spécifier votre emplacement sur la carte")
-      end
+    if latitude.nil? || longitude.nil? 
+      errors.add(:base, "Veuillez spécifier votre emplacement sur la carte")
+    end
   end
 
   def color

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -4,6 +4,7 @@ class Card < ApplicationRecord
   attr_accessor :current_step
 
   default_scope -> { where.not(status: :incomplete) }
+  scope :with_incomplete, -> { rewhere(status: :incomplete) }
   scope :active_networks, -> { where(status: :online, card_type: :network) }
 
   enum card_type: [:youth, :adult, :activist, :organization, :network, :training]

--- a/app/views/admin/cards/edit.html.erb
+++ b/app/views/admin/cards/edit.html.erb
@@ -48,7 +48,7 @@
 
       <div class="row">
         <%= f.label :parent_ids %>
-        <%= f.collection_select :parent_ids, Card.network, :id, :name, {}, { multiple: true, "data-controller": "select--simple" } %>
+        <%= f.collection_select :parent_ids, Card.active_networks, :id, :name, {}, { multiple: true, "data-controller": "select--simple" } %>
       </div>
 
       <div class="row">

--- a/app/views/cards/wizards/_general_step.html.erb
+++ b/app/views/cards/wizards/_general_step.html.erb
@@ -20,6 +20,6 @@
 
   <div class="row">
     <%= f.label :parent_ids, "Affiliation" %>
-    <%= f.collection_select :parent_ids, Card.network, :id, :name, {}, { multiple: true, "data-controller": "select--simple" } %>
+    <%= f.collection_select :parent_ids, Card.active_networks, :id, :name, {}, { multiple: true, "data-controller": "select--simple" } %>
   </div>
 </div>

--- a/app/views/users/cards/edit.html.erb
+++ b/app/views/users/cards/edit.html.erb
@@ -60,7 +60,7 @@
 
     <div class="field">
       <%= f.label :parent_ids %>
-      <%= f.collection_select :parent_ids, Card.network, :id, :name, {}, { multiple: true, "data-controller": "select--simple" } %>
+      <%= f.collection_select :parent_ids, Card.active_networks, :id, :name, {}, { multiple: true, "data-controller": "select--simple" } %>
     </div>
     
     <div class="field">

--- a/features/cards/confirmation.feature
+++ b/features/cards/confirmation.feature
@@ -8,8 +8,9 @@ Feature: Confirm the card
     Given I am a confirmed user
     And I am signed in
 
+  @javascript @locations
   Scenario: I successfully confirm the card
-    Given I have a complete card
+    Given I have an incomplete card
     When I visit the card confirmation page
     And I click the link "Confirmer"
     Then I should see a flash with "Vous êtes entré dans le réseau avec succès ! Votre groupe n'apparaît pas directement sur la carte car il doit d'abord être validé."

--- a/features/step_definitions/cards/confirmation_steps.rb
+++ b/features/step_definitions/cards/confirmation_steps.rb
@@ -2,6 +2,14 @@ Given("I have a complete card") do
   @card = create(:card, user: @user)
 end
 
+Given("I have an incomplete card") do
+  visit "/cards/wizards/new"
+  step "I complete the first step and submit it"
+  step "I complete the second step and submit it"
+  step "I complete the third step and submit it"
+end
+
 When("I visit the card confirmation page") do
-  visit confirmation_cards_wizard_path(Card.last)
+  card = @card || Card.rewhere(status: :incomplete).last
+  visit confirmation_cards_wizard_path(card)
 end

--- a/spec/controllers/cards/wizards_controller_spec.rb
+++ b/spec/controllers/cards/wizards_controller_spec.rb
@@ -7,7 +7,7 @@ module Cards
     describe "#confirm" do
 
       it "updates the card status to pending" do
-        @card = create(:card, status: nil)
+        @card = create(:card, status: :incomplete)
         request.cookies[:remember_token] = @card.user.remember_token
         patch :confirm, params: { id: @card.id }
         @card.reload

--- a/spec/controllers/users/cards_controller_spec.rb
+++ b/spec/controllers/users/cards_controller_spec.rb
@@ -7,7 +7,7 @@ module Users
     describe "#transfer" do
 
       it "transfers the card to another user" do
-        @card = create(:card, status: nil)
+        @card = create(:card)
         request.cookies[:remember_token] = @card.user.remember_token
         email = "another@bar.com"
         @another_user = create(:user, email: email, confirmed: true)
@@ -17,7 +17,7 @@ module Users
       end
 
       it "does not transfer the card" do
-        @card = create(:card, status: nil)
+        @card = create(:card)
         @user = @card.user
         request.cookies[:remember_token] = @user.remember_token
         post :transfer, params: { id: @card.id, email: "nil@bar.com" }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -27,10 +27,7 @@ FactoryBot.define do
     user
     location { Location.find_by_official_name("Bulle") || create(:location) }
     card_type { :youth }
-
-    factory :active_card do
-      status { :online }
-    end
+    status { :online }
   end
 
   factory :location do


### PR DESCRIPTION
Now, by default, Card that are incomplete are excluded from requests.
For instance, `Card.all` yields `Card.where.not(status: :incomplete)`.